### PR TITLE
Save DataRecorder records to a persistent location

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,7 +17,8 @@ config :nautic_net_device,
   udp_endpoint: System.fetch_env!("UDP_ENDPOINT"),
   product: System.fetch_env!("PRODUCT"),
   replay_log: System.get_env("REPLAY_LOG"),
-  git_commit: git_commit
+  git_commit: git_commit,
+  data_set_directory: System.tmp_dir!() |> Path.join("data_set")
 
 # Customize non-Elixir parts of the firmware. See
 # https://hexdocs.pm/nerves/advanced-configuration.html for details.

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,8 +17,7 @@ config :nautic_net_device,
   udp_endpoint: System.fetch_env!("UDP_ENDPOINT"),
   product: System.fetch_env!("PRODUCT"),
   replay_log: System.get_env("REPLAY_LOG"),
-  git_commit: git_commit,
-  data_set_directory: System.tmp_dir!() |> Path.join("datasets")
+  git_commit: git_commit
 
 # Customize non-Elixir parts of the firmware. See
 # https://hexdocs.pm/nerves/advanced-configuration.html for details.

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,7 +18,7 @@ config :nautic_net_device,
   product: System.fetch_env!("PRODUCT"),
   replay_log: System.get_env("REPLAY_LOG"),
   git_commit: git_commit,
-  data_set_directory: System.tmp_dir!() |> Path.join("data_set")
+  data_set_directory: System.tmp_dir!() |> Path.join("datasets")
 
 # Customize non-Elixir parts of the firmware. See
 # https://hexdocs.pm/nerves/advanced-configuration.html for details.

--- a/config/target.exs
+++ b/config/target.exs
@@ -34,7 +34,8 @@ case System.get_env("CAN_DRIVER") do
 end
 
 config :nautic_net_device,
-  tailscale_auth_key: System.get_env("TAILSCALE_AUTH_KEY")
+  tailscale_auth_key: System.get_env("TAILSCALE_AUTH_KEY"),
+  data_set_directory: "/root/data_set"
 
 config :logger, level: :debug
 

--- a/config/target.exs
+++ b/config/target.exs
@@ -35,7 +35,7 @@ end
 
 config :nautic_net_device,
   tailscale_auth_key: System.get_env("TAILSCALE_AUTH_KEY"),
-  data_set_directory: "/data/data_set"
+  data_set_directory: "/data/datasets"
 
 config :logger, level: :debug
 

--- a/config/target.exs
+++ b/config/target.exs
@@ -35,7 +35,7 @@ end
 
 config :nautic_net_device,
   tailscale_auth_key: System.get_env("TAILSCALE_AUTH_KEY"),
-  data_set_directory: "/root/data_set"
+  data_set_directory: "/data/data_set"
 
 config :logger, level: :debug
 

--- a/lib/nautic_net/data_set_recorder.ex
+++ b/lib/nautic_net/data_set_recorder.ex
@@ -15,8 +15,6 @@ defmodule NauticNet.DataSetRecorder do
   alias NauticNet.Protobuf
   alias NauticNet.Protobuf.DataSet
 
-  @default_dataset_dir Application.get_env(:nautic_net_device, :data_set_directory)
-
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
@@ -113,8 +111,9 @@ defmodule NauticNet.DataSetRecorder do
       :ok = File.mkdir_p!(tmp_dir)
       tmp_dir
     else
-      :ok = File.mkdir_p!(@default_dataset_dir)
-      @default_dataset_dir
+      dir = Application.get_env(:nautic_net_device, :data_set_directory, Path.join(System.tmp_dir!(), "datasets"))
+      :ok = File.mkdir_p!(dir)
+      dir
     end
   end
 end

--- a/lib/nautic_net/data_set_recorder.ex
+++ b/lib/nautic_net/data_set_recorder.ex
@@ -2,7 +2,7 @@ defmodule NauticNet.DataSetRecorder do
   @moduledoc """
   Writes DataSets to disk so that we don't lose it, and then enqueues it for upload to the server.
 
-  The files are written to /tmp/datasets/{random base-64} in the raw Protobuf format, which can
+  The files are written to /data/datasets/{random base-64} when on device in the raw Protobuf format, which can
   be sent directly to server without any changes.
 
   See also: NauticNet.DataSetUploader


### PR DESCRIPTION
Write the protobuf records to a persistent location so data is not lost when power is removed from the device but data is still waiting to be uploaded.

Fixes #11 