### PR TITLE
Refactor J1939 into NMEA2000 namespace

### DIFF
--- a/config/host_dev.exs
+++ b/config/host_dev.exs
@@ -4,7 +4,7 @@
 
 import Config
 
-alias NauticNet.NMEA2000.J1939
+alias NauticNet.NMEA2000.ParameterGroup
 
 config :logger, level: :debug, backends: [:console]
 
@@ -18,8 +18,8 @@ config :nautic_net_device, NauticNet.CAN,
     # NauticNet.PacketHandler.SetTimeFromGPS,
     {NauticNet.PacketHandler.Inspect,
      only: [
-       J1939.ISORequestParams,
-       J1939.ISOAddressClaimParams,
-       J1939.ProductInformationParams
+       ParameterGroup.ISORequestParams,
+       ParameterGroup.ISOAddressClaimParams,
+       ParameterGroup.ProductInformationParams
      ]}
   ]

--- a/lib/nautic_net/device_cli.ex
+++ b/lib/nautic_net/device_cli.ex
@@ -8,8 +8,8 @@ defmodule NauticNet.DeviceCLI do
   alias NauticNet.CAN.Fake
   alias NauticNet.Discovery
   alias NauticNet.NMEA2000.Frame
-  alias NauticNet.NMEA2000.J1939.ISOAddressClaimParams
-  alias NauticNet.NMEA2000.J1939.PGN
+  alias NauticNet.NMEA2000.ParameterGroup.ISOAddressClaimParams
+  alias NauticNet.NMEA2000.PGN
 
   def start_logging_canusb do
     CANUSB.Server.start_logging()

--- a/lib/nautic_net/discovery/server.ex
+++ b/lib/nautic_net/discovery/server.ex
@@ -6,8 +6,8 @@ defmodule NauticNet.Discovery.Server do
   alias NauticNet.DeviceInfo
   alias NauticNet.Network
   alias NauticNet.NMEA2000.Manufacturers
-  alias NauticNet.NMEA2000.J1939.ISOAddressClaimParams
-  alias NauticNet.NMEA2000.J1939.ProductInformationParams
+  alias NauticNet.NMEA2000.ParameterGroup.ISOAddressClaimParams
+  alias NauticNet.NMEA2000.ParameterGroup.ProductInformationParams
   alias NauticNet.NMEA2000.Packet
 
   @name __MODULE__

--- a/lib/nautic_net/network.ex
+++ b/lib/nautic_net/network.ex
@@ -4,9 +4,9 @@ defmodule NauticNet.Network do
   """
 
   alias NauticNet.CAN
-  alias NauticNet.NMEA2000.J1939.ISOAddressClaimParams
-  alias NauticNet.NMEA2000.J1939.ISORequestParams
-  alias NauticNet.NMEA2000.J1939.ProductInformationParams
+  alias NauticNet.NMEA2000.ParameterGroup.ISOAddressClaimParams
+  alias NauticNet.NMEA2000.ParameterGroup.ISORequestParams
+  alias NauticNet.NMEA2000.ParameterGroup.ProductInformationParams
   alias NauticNet.NMEA2000.Packet
 
   def request_address_claims do

--- a/lib/nautic_net/packet_handler/create_gps_log.ex
+++ b/lib/nautic_net/packet_handler/create_gps_log.ex
@@ -1,7 +1,7 @@
 defmodule NauticNet.PacketHandler.CreateGPSLog do
   @behaviour NauticNet.PacketHandler
 
-  alias NauticNet.NMEA2000.J1939.GNSSPositionDataParams
+  alias NauticNet.NMEA2000.ParameterGroup.GNSSPositionDataParams
   alias NauticNet.NMEA2000.Packet
 
   @gpx_header """
@@ -67,8 +67,7 @@ defmodule NauticNet.PacketHandler.CreateGPSLog do
       }) do
     time = params.datetime |> DateTime.truncate(:second) |> DateTime.to_iso8601()
 
-    trkpt =
-      ~s[<trkpt lat="#{params.latitude}" lon="#{params.longitude}"><time>#{time}></time></trkpt>]
+    trkpt = ~s[<trkpt lat="#{params.latitude}" lon="#{params.longitude}"><time>#{time}></time></trkpt>]
 
     IO.puts(file, trkpt)
   end

--- a/lib/nautic_net/packet_handler/emit_telemetry.ex
+++ b/lib/nautic_net/packet_handler/emit_telemetry.ex
@@ -4,7 +4,7 @@ defmodule NauticNet.PacketHandler.EmitTelemetry do
   alias NauticNet.DeviceInfo
   alias NauticNet.Discovery
   alias NauticNet.NMEA2000.Packet
-  alias NauticNet.NMEA2000.J1939
+  alias NauticNet.NMEA2000.ParameterGroup
 
   @impl NauticNet.PacketHandler
   def init(_opts) do
@@ -12,7 +12,7 @@ defmodule NauticNet.PacketHandler.EmitTelemetry do
   end
 
   @impl NauticNet.PacketHandler
-  def handle_packet(%Packet{parameters: %J1939.WindDataParams{} = params} = packet, _config) do
+  def handle_packet(%Packet{parameters: %ParameterGroup.WindDataParams{} = params} = packet, _config) do
     execute([:nautic_net, :wind, params.wind_reference], packet, %{
       vector: %{
         timestamp: packet.timestamp,
@@ -22,7 +22,7 @@ defmodule NauticNet.PacketHandler.EmitTelemetry do
     })
   end
 
-  def handle_packet(%Packet{parameters: %J1939.GNSSPositionDataParams{} = params} = packet, _config) do
+  def handle_packet(%Packet{parameters: %ParameterGroup.GNSSPositionDataParams{} = params} = packet, _config) do
     execute([:nautic_net, :gps], packet, %{
       position: %{
         timestamp: packet.timestamp,
@@ -32,7 +32,7 @@ defmodule NauticNet.PacketHandler.EmitTelemetry do
     })
   end
 
-  def handle_packet(%Packet{parameters: %J1939.TemperatureParams{} = params} = packet, _config) do
+  def handle_packet(%Packet{parameters: %ParameterGroup.TemperatureParams{} = params} = packet, _config) do
     execute([:nautic_net, :temperature], packet, %{
       timestamp: packet.timestamp,
       kelvin: params.temperature_k
@@ -40,7 +40,10 @@ defmodule NauticNet.PacketHandler.EmitTelemetry do
   end
 
   # Discard (UINT16_MAX / 100)
-  def handle_packet(%Packet{parameters: %J1939.SpeedParams{water_speed: water_speed} = params} = packet, _config)
+  def handle_packet(
+        %Packet{parameters: %ParameterGroup.SpeedParams{water_speed: water_speed} = params} = packet,
+        _config
+      )
       when water_speed != 655.35 do
     execute([:nautic_net, :speed, :water], packet, %{
       speed_m_s: %{
@@ -51,7 +54,7 @@ defmodule NauticNet.PacketHandler.EmitTelemetry do
   end
 
   # Discard (UINT32_MAX / 100)
-  def handle_packet(%Packet{parameters: %J1939.WaterDepthParams{depth: depth_m}} = packet, _config)
+  def handle_packet(%Packet{parameters: %ParameterGroup.WaterDepthParams{depth: depth_m}} = packet, _config)
       when depth_m != 42_949_672.95 do
     execute([:nautic_net, :water_depth], packet, %{
       depth_m: %{
@@ -61,7 +64,7 @@ defmodule NauticNet.PacketHandler.EmitTelemetry do
     })
   end
 
-  def handle_packet(%Packet{parameters: %J1939.VesselHeadingParams{} = params} = packet, _config) do
+  def handle_packet(%Packet{parameters: %ParameterGroup.VesselHeadingParams{} = params} = packet, _config) do
     execute([:nautic_net, :heading], packet, %{
       rad: %{
         timestamp: packet.timestamp,
@@ -70,7 +73,7 @@ defmodule NauticNet.PacketHandler.EmitTelemetry do
     })
   end
 
-  def handle_packet(%Packet{parameters: %J1939.VelocityOverGroundParams{} = params} = packet, _config) do
+  def handle_packet(%Packet{parameters: %ParameterGroup.VelocityOverGroundParams{} = params} = packet, _config) do
     execute([:nautic_net, :velocity, :ground], packet, %{
       vector: %{
         timestamp: packet.timestamp,

--- a/lib/nautic_net/packet_handler/set_time_from_gps.ex
+++ b/lib/nautic_net/packet_handler/set_time_from_gps.ex
@@ -3,7 +3,7 @@ defmodule NauticNet.PacketHandler.SetTimeFromGPS do
 
   require Logger
 
-  alias NauticNet.NMEA2000.J1939.GNSSPositionDataParams
+  alias NauticNet.NMEA2000.ParameterGroup.GNSSPositionDataParams
   alias NauticNet.NMEA2000.Packet
 
   @impl NauticNet.PacketHandler

--- a/test/nautic_net/can_test.exs
+++ b/test/nautic_net/can_test.exs
@@ -32,7 +32,7 @@ defmodule NauticNet.CANTest do
       frame_id: 0,
       frame_type: :extended,
       packet_type: :single,
-      parameters: %NauticNet.NMEA2000.J1939.WindDataParams{
+      parameters: %NauticNet.NMEA2000.ParameterGroup.WindDataParams{
         sid: 250,
         wind_angle: 5.7232,
         wind_reference: :apparent,
@@ -58,15 +58,14 @@ defmodule NauticNet.CANTest do
 
     assert_receive %NauticNet.NMEA2000.Packet{
       data:
-        <<201, 227, 74, 128, 42, 234, 31, 128, 255, 209, 139, 175, 114, 221, 5, 128, 84, 110, 204,
-          210, 97, 41, 246, 48, 146, 153, 254, 255, 255, 255, 255, 16, 252, 12, 80, 0, 140, 0,
-          204, 242, 255, 255, 255>>,
+        <<201, 227, 74, 128, 42, 234, 31, 128, 255, 209, 139, 175, 114, 221, 5, 128, 84, 110, 204, 210, 97, 41, 246, 48,
+          146, 153, 254, 255, 255, 255, 255, 16, 252, 12, 80, 0, 140, 0, 204, 242, 255, 255, 255>>,
       data_size: 43,
       description: nil,
       frame_id: 6,
       frame_type: :extended,
       packet_type: :fast,
-      parameters: %NauticNet.NMEA2000.J1939.GNSSPositionDataParams{
+      parameters: %NauticNet.NMEA2000.ParameterGroup.GNSSPositionDataParams{
         altitude: -23.49,
         datetime: ~U[2022-06-28T14:52:24.000000Z],
         latitude: 42.26200383333334,


### PR DESCRIPTION
Remove J1939 namespace and move everything up to NMEA2000 namespace.

NOTE: Requires nautic_net_nmea2000 update first so deps can be updated before merging.